### PR TITLE
Generalize PDF exporting info

### DIFF
--- a/packages.sty
+++ b/packages.sty
@@ -213,13 +213,13 @@ bindingoffset=15mm,marginpar=1.5cm,reversemp]{geometry}
 
 \usepackage{comment}
 % per poter gestire commenti pi� lunghi
-
+% Inserire qui le info per il PDF esportato
 \usepackage[colorlinks,hyperindex,pagebackref]{hyperref}
 \hypersetup{
-			pdftitle={Aspetti legislativi e progettuali inerenti alla realizzazione degli impianti geotermici},
-			pdfsubject={Universit� di Padova, Facolt� di Ingegneria},
-			pdfauthor={Nicola Rainiero},
-			pdfkeywords={geotecnica, energia, geotermia, legge, sonde},
+			pdftitle={Title},
+			pdfsubject={University},
+			pdfauthor={Author},
+			pdfkeywords={keyword1, keyword2, keyword3},
 			%pdfpagemode=FullScreen, % avvia a pieno schermo
 			citecolor=black,
 			filecolor=black,


### PR DESCRIPTION
Add placeholder instead of real information to export to PDF data on title, author, subject and keywords